### PR TITLE
renamed release-notes to match workflow

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: docker://tiangolo/latest-changes
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          latest_changes_file: docs/release-notes.md
+          latest_changes_file: docs/RELEASE-NOTES.md
           latest_changes_header: '# Release Notes'
           template_file: ./.github/workflows/release-notes.jinja2
           # The next release will start with this RegEx, for example "## 0.2.0"


### PR DESCRIPTION
latest_changes_file in workflows/latest-changes.yml didn't match name release-notes.md.
Opted to rename release-notes.md to match markdown style. (They're all supposed to be capitalized."